### PR TITLE
Prevent deleting chip from submitting form

### DIFF
--- a/src/chips/Chip.style.js
+++ b/src/chips/Chip.style.js
@@ -1,4 +1,4 @@
-import { setDisplayName } from 'recompose';
+import { compose, defaultProps, setDisplayName } from 'recompose';
 import styled, { css } from 'styled-components';
 
 import { getters as g } from '../util';
@@ -41,7 +41,12 @@ export const ChipText = setDisplayName('ChipText')(styled.span`
   display: inline-block;
 `);
 
-export const ChipAction = setDisplayName('ChipAction')(styled.button`
+export const ChipAction = compose(
+  defaultProps({
+    type: 'button',
+  }),
+  setDisplayName('ChipAction'),
+)(styled.button`
   height: 24px;
   width: 24px;
   font-size: 24px;


### PR DESCRIPTION
Buttons trigger submits of whatever form they are in unless they have `type="button"`. We may want this to be configurable (I can't imagine why), but at the very least this is sane default behavior. This can be very important when the chip is used as an item/list within a form field.

Also, we may want to add some sort of actual browser testing for regressions as I wasn't able to reproduce this using enzyme (neither shallow nor mount). Doing that is a whole other thing, but this could be a good case for the first browser regression test.